### PR TITLE
doc: Include the jsonschema

### DIFF
--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -15,3 +15,9 @@ RPM spec files, ...).
   ---
   tests:
     - name: first-test
+
+_obsci schema validation
+------------------------
+The jsonschema that is used to validate the `_obsci` file is:
+
+.. literalinclude:: ../../obsci/worker/config_package_schema.json


### PR DESCRIPTION
To make it explicit how a _obsci file is validated, include the
jsonschema file in the docs.