### PR TITLE
travis: Only deploy docs from docs tox env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ deploy:
   github_token: $GITHUB_TOKEN
   on:
     branch: master
+    condition: $TOX_ENV = docs


### PR DESCRIPTION
Otherwise, the deploy job fails (eg. for the pep8 or py36 job) because
no docs are available.