### PR TITLE
travis: Keep history for github pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,6 @@ deploy:
   skip_cleanup: true
   local_dir: doc/build/html
   github_token: $GITHUB_TOKEN
+  keep_history: true
   on:
     branch: master


### PR DESCRIPTION
A .nojekyll was manually added to the gh-pages branch so force commits
are not allowed anymore (to not remove .nojekyll again).