### PR TITLE
doc: Another try to add a .nojekyll file

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -63,6 +63,8 @@ pygments_style = 'sphinx'
 # html_theme_path = ["."]
 # html_theme = '_theme'
 # html_static_path = ['static']
+
+html_extra_path = ['extra_files']
 #html_theme = 'alabaster'
 html_theme = "sphinx_rtd_theme"
 

--- a/doc/source/extra_files/.nojekyll
+++ b/doc/source/extra_files/.nojekyll
@@ -1,0 +1,1 @@
+# Needed for github pages to not ignore directories starting with "_" (like _static)


### PR DESCRIPTION
After the doc theme switch, the github pages docs were broken
again. This is another attempt to fix this.